### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Jekyll site CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/DavidRigueira/PuntuacionesJugadoresFrontent/security/code-scanning/2](https://github.com/DavidRigueira/PuntuacionesJugadoresFrontent/security/code-scanning/2)

To address this issue, we need to add an explicit `permissions` block to the workflow. Since all jobs in this workflow (currently only one job, `build`) require only the minimal necessary permissions, the best-practice fix is to add the following at the root (top-level) of the workflow file:  
```yaml
permissions:
  contents: read
```
This restricts the GITHUB_TOKEN used by all jobs to only read repository contents. The `permissions` block should be inserted immediately after the `name:` key and before the `on:` key—commonly after line 1 or 2, before the workflow triggers. No additional imports, methods, or definitions are required: this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
