### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -12,6 +12,8 @@
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DavidRigueira/PuntuacionesJugadoresFrontent/security/code-scanning/3](https://github.com/DavidRigueira/PuntuacionesJugadoresFrontent/security/code-scanning/3)

To fix the problem, you need to add a `permissions` block to the workflow to apply the principle of least privilege. Since the workflow does not require any write access--it only checks out code, builds in Jekyll, and triggers Datadog synthetic tests--the best fix is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), thereby restricting the GITHUB_TOKEN to read-only access to repository contents. This ensures the workflow cannot inadvertently perform write operations to the repository or other sensitive actions. The change should be made near the top of `.github/workflows/datadog-synthetics.yml`, after the `name:` and before the `on:` section.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
